### PR TITLE
[#2]init : docker mysql 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: ocean-backend
+    environment:
+      MYSQL_ROOT_PASSWORD: admin
+      MYSQL_DATABASE: ocean-backend
+      MYSQL_USER: admin
+      MYSQL_PASSWORD: admin
+    ports:
+      - "3306:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+    networks:
+      - app-network
+    healthcheck:
+      test: [ "CMD", "ocean-backend", "ping", "-h", "localhost" ]
+      timeout: 20s
+      retries: 10
+    restart: always
+
+networks:
+  app-network:
+    driver: bridge
+volumes:
+  db-data:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,14 @@
 spring.application.name=ocean-backend
+spring.datasource.url=jdbc:localhost://ocean-backend:3306/ocean-backend?rewriteBatchedStatements=true&profileSQL=true&logger=Slf4JLogger&maxQuerySizeToLog=999999
+spring.datasource.username=admin
+spring.datasource.password=admin
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.use_sql_comments=true
+spring.jpa.properties.hibernate.jdbc.batch_size=100
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+jwt.secret.key=7Iqk7YyM66W07YOA7L2U65Sp7YG065+9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg==


### PR DESCRIPTION
- 제목 : [#2]init : docker mysql 설정 추가
## 🔘Part

- 개발환경 설정(docker)

  <br/>

## 🔎 작업 내용

- docker-compose 설정을 통해 LocalMysql 설정 공통화
- 3306 포트가 실행중이 아니어야 합니다.
- 프로젝트 파일내에서 터미널 `docker-compose up -d` 명령어 실행필요.

  <br/>

## 🔧 앞으로의 과제

- Redis 설정 추가 및 docker 를 통한 설정추가