### PR TITLE
[#27]fix : 로그인유저 정보 받아오기 추가, 잘못된 카테고리 작성 예외처리 변경

### DIFF
--- a/src/main/java/com/sparta/oceanbackend/api/post/controller/PostController.java
+++ b/src/main/java/com/sparta/oceanbackend/api/post/controller/PostController.java
@@ -1,15 +1,14 @@
 package com.sparta.oceanbackend.api.post.controller;
 
+import com.sparta.oceanbackend.api.auth.annotation.AuthUser;
 import com.sparta.oceanbackend.api.post.dto.request.PostCreateRequest;
 import com.sparta.oceanbackend.api.post.dto.response.PostCreateResponse;
 import com.sparta.oceanbackend.api.post.service.PostService;
-import com.sparta.oceanbackend.api.user.service.UserDetailsServiceImpl;
+import com.sparta.oceanbackend.domain.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,11 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
 public class PostController {
-    private final PostService postService;
+  private final PostService postService;
 
-    @PostMapping
-    public ResponseEntity<PostCreateResponse> createPost(@AuthenticationPrincipal
-    UserDetails impl,@Valid @RequestBody PostCreateRequest postCreateRequest){
-        return ResponseEntity.status(HttpStatus.CREATED).body(postService.createPost(postCreateRequest, impl.getUsername()));
-    }
+  @PostMapping
+  public ResponseEntity<PostCreateResponse> createPost(
+      @AuthUser User user, @Valid @RequestBody PostCreateRequest postCreateRequest) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(postService.createPost(postCreateRequest, user));
+  }
 }

--- a/src/main/java/com/sparta/oceanbackend/api/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/sparta/oceanbackend/api/post/dto/request/PostCreateRequest.java
@@ -1,7 +1,9 @@
 package com.sparta.oceanbackend.api.post.dto.request;
 
 import com.sparta.oceanbackend.api.enums.Categorys;
+import com.sparta.oceanbackend.common.annotation.ValidEnum;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
@@ -12,5 +14,7 @@ public class PostCreateRequest {
     private String title;
     @NotBlank(message = "내용을 입력해주세요")
     private String content;
-    private Categorys category;
+    @NotNull(message = "카테고리를 선택해주세요")
+    @ValidEnum(enumClass = Categorys.class, message = "올바른 카테고리를 선택해주세요")
+    private String category;
 }

--- a/src/main/java/com/sparta/oceanbackend/api/post/service/PostService.java
+++ b/src/main/java/com/sparta/oceanbackend/api/post/service/PostService.java
@@ -1,24 +1,30 @@
 package com.sparta.oceanbackend.api.post.service;
 
+import com.sparta.oceanbackend.api.enums.Categorys;
 import com.sparta.oceanbackend.api.post.dto.request.PostCreateRequest;
 import com.sparta.oceanbackend.api.post.dto.response.PostCreateResponse;
 import com.sparta.oceanbackend.domain.post.entity.Post;
 import com.sparta.oceanbackend.domain.post.repository.PostRepository;
 import com.sparta.oceanbackend.domain.user.entity.User;
-import com.sparta.oceanbackend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
 
-    private final PostRepository postRepository;
-    private final UserRepository userRepository;
+  private final PostRepository postRepository;
 
-    public PostCreateResponse createPost(PostCreateRequest postCreateRequest, String name) {
-        User user = userRepository.findByName(name).orElseThrow(() -> new IllegalArgumentException("유저없어요"));
-        Post post = Post.builder().title(postCreateRequest.getTitle()).content(postCreateRequest.getContent()).category(postCreateRequest.getCategory()).user(user).build();
-        return new PostCreateResponse(postRepository.save(post).getId());
-    }
+  @Transactional
+  public PostCreateResponse createPost(PostCreateRequest postCreateRequest, User user) {
+    Post post =
+        Post.builder()
+            .title(postCreateRequest.getTitle())
+            .content(postCreateRequest.getContent())
+            .category(Categorys.valueOf(postCreateRequest.getCategory()))
+            .user(user)
+            .build();
+    return new PostCreateResponse(postRepository.save(post).getId());
+  }
 }

--- a/src/main/java/com/sparta/oceanbackend/common/annotation/ValidEnum.java
+++ b/src/main/java/com/sparta/oceanbackend/common/annotation/ValidEnum.java
@@ -1,0 +1,23 @@
+package com.sparta.oceanbackend.common.annotation;
+
+import com.sparta.oceanbackend.common.validator.ValueOfEnumValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = ValueOfEnumValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+    Class<? extends Enum<?>> enumClass();
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/sparta/oceanbackend/common/validator/ValueOfEnumValidator.java
+++ b/src/main/java/com/sparta/oceanbackend/common/validator/ValueOfEnumValidator.java
@@ -1,0 +1,24 @@
+package com.sparta.oceanbackend.common.validator;
+
+import com.sparta.oceanbackend.common.annotation.ValidEnum;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValueOfEnumValidator implements ConstraintValidator<ValidEnum,String> {
+    private Class<? extends Enum<?>> enumClass;
+
+    @Override
+    public void initialize(ValidEnum constraintAnnotation) {
+        this.enumClass = constraintAnnotation.enumClass();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        for (Enum<?> enumConstant : enumClass.getEnumConstants()) {
+            if (enumConstant.name().equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
- 제목 : [#27]fix : 로그인유저 정보 받아오기 추가, 잘못된 카테고리 작성 예외처리 변경
## 🔘Part

- 게시글 작성기능

  <br/>

## 🔎 작업 내용

- 로그인유저를 통한 정보 받아오기 추가
- 잘못된 카테고리로 작성 요청시 예외발생 추가

  <br/>

## 🔧 앞으로의 과제

- 테스트코드 추가, 게시글 추가기능 작업