### PR TITLE
 [#38]feat : docker Redis 추가 및 프로젝트 연결 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,12 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   mysql:
     image: mysql:8.0
-    container_name: ocean-backend
+    container_name: ocean-backend-mysql
     environment:
       MYSQL_ROOT_PASSWORD: admin
       MYSQL_DATABASE: ocean-backend
@@ -17,6 +17,17 @@ services:
       test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
       timeout: 20s
       retries: 10
+    restart: always
+
+  redis:
+    image: redis:7.0
+    container_name: ocean-backend-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./db/redis/data:/data
+    environment:
+      TZ: Asia/Seoul
     restart: always
 
 networks:

--- a/src/main/java/com/sparta/oceanbackend/config/RedisConfig.java
+++ b/src/main/java/com/sparta/oceanbackend/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.sparta.oceanbackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Bean
+  // Lettuce 라이브러리 사용
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, port);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,4 +11,6 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 spring.jpa.properties.hibernate.jdbc.batch_size=100
 spring.jpa.properties.hibernate.order_inserts=true
 spring.jpa.properties.hibernate.order_updates=true
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
 jwt.secret.key=7Iqk7YyM66W07YOA7L2U65Sp7YG065+9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg==

--- a/src/test/java/com/sparta/oceanbackend/RedisSpringBootTest.java
+++ b/src/test/java/com/sparta/oceanbackend/RedisSpringBootTest.java
@@ -1,28 +1,28 @@
-package com.sparta.oceanbackend;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
-
-@SpringBootTest
-public class RedisSpringBootTest {
-
-  @Autowired private RedisTemplate<String, String> redisTemplate;
-
-  @Test
-  void testRedisTemplate() {
-    ValueOperations<String, String> ops = redisTemplate.opsForValue();
-    // 저장
-    ops.set("key", "value");
-    // 조회
-    String value = ops.get("key");
-    assertThat(value).isEqualTo("value");
-    // 삭제
-    redisTemplate.delete("key");
-    assertThat(ops.get("key")).isNull();
-  }
-}
+//package com.sparta.oceanbackend;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.data.redis.core.ValueOperations;
+//
+//@SpringBootTest
+//public class RedisSpringBootTest {
+//
+//  @Autowired private RedisTemplate<String, String> redisTemplate;
+//
+//  @Test
+//  void testRedisTemplate() {
+//    ValueOperations<String, String> ops = redisTemplate.opsForValue();
+//    // 저장
+//    ops.set("key", "value");
+//    // 조회
+//    String value = ops.get("key");
+//    assertThat(value).isEqualTo("value");
+//    // 삭제
+//    redisTemplate.delete("key");
+//    assertThat(ops.get("key")).isNull();
+//  }
+//}

--- a/src/test/java/com/sparta/oceanbackend/RedisSpringBootTest.java
+++ b/src/test/java/com/sparta/oceanbackend/RedisSpringBootTest.java
@@ -1,0 +1,28 @@
+package com.sparta.oceanbackend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@SpringBootTest
+public class RedisSpringBootTest {
+
+  @Autowired private RedisTemplate<String, String> redisTemplate;
+
+  @Test
+  void testRedisTemplate() {
+    ValueOperations<String, String> ops = redisTemplate.opsForValue();
+    // 저장
+    ops.set("key", "value");
+    // 조회
+    String value = ops.get("key");
+    assertThat(value).isEqualTo("value");
+    // 삭제
+    redisTemplate.delete("key");
+    assertThat(ops.get("key")).isNull();
+  }
+}


### PR DESCRIPTION
- 제목 :  [#38]feat : docker Redis 추가 및 프로젝트 연결 
## 🔘Part

- 개발환경 설정(docker)

  <br/>

## 🔎 작업 내용

- docker-compose 설정을 통해 LocalRedis 설정 공통화
- 6379 포트가 실행중이 아니어야 합니다.
- 프로젝트 파일내에서 터미널 `docker-compose up -d` 명령어 실행필요.

  <br/>

## 🔧 앞으로의 과제

- Redis를 이용한 캐싱전략 수립