### PR TITLE
[#48]feat : 인기게시글 조회 v1,2,3 기능 추가, fix : 유저 인기게시글 생성,수정,삭제 기능 차단

### DIFF
--- a/src/main/java/com/sparta/oceanbackend/api/enums/Categorys.java
+++ b/src/main/java/com/sparta/oceanbackend/api/enums/Categorys.java
@@ -4,5 +4,6 @@ public enum Categorys {
     NEWS_FORUM,
     HUMOR_FORUM,
     OPEN_FORUM,
-    HEALTH_FORUM
+    HEALTH_FORUM,
+    BEST_FORUM
 }

--- a/src/main/java/com/sparta/oceanbackend/api/post/controller/PostController.java
+++ b/src/main/java/com/sparta/oceanbackend/api/post/controller/PostController.java
@@ -39,6 +39,13 @@ public class PostController {
         .body(postService.createPost(postCreateRequest, user));
   }
 
+  /*
+   * 모든 게시판 검색
+   * v1 . NonCache
+   * v2 . InMemory-Cache
+   * v3 . Redis-Cache
+   */
+
   @GetMapping("/search/v1")
   public ResponseEntity<Page<PostReadResponse>> searchPosts(
       @RequestParam String keyword,
@@ -64,6 +71,40 @@ public class PostController {
       @RequestParam(defaultValue = "10") int pagesize) {
     return ResponseEntity.status(HttpStatus.OK)
         .body(postService.searchPostsRedis(pagenumber, pagesize, keyword));
+  }
+
+  /*
+   * 인기 게시판 검색
+   * v1 . NonCache
+   * v2 . InMemory-Cache
+   * v3 . Redis-Cache
+   */
+
+  @GetMapping("/search/best/v1")
+  public ResponseEntity<Page<PostReadResponse>> searchPostsBest(
+      @RequestParam String keyword,
+      @RequestParam(defaultValue = "1") int pagenumber,
+      @RequestParam(defaultValue = "10") int pagesize) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(postService.searchPostsBest(pagenumber, pagesize, keyword));
+  }
+
+  @GetMapping("/search/best/v2")
+  public ResponseEntity<Page<PostReadResponse>> searchPostsBestInMemory(
+      @RequestParam String keyword,
+      @RequestParam(defaultValue = "1") int pagenumber,
+      @RequestParam(defaultValue = "10") int pagesize) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(postService.searchPostsBestInMemory(pagenumber, pagesize, keyword));
+  }
+
+  @GetMapping("/search/best/v3")
+  public ResponseEntity<Page<PostReadResponse>> searchPostsBestRedis(
+      @RequestParam String keyword,
+      @RequestParam(defaultValue = "1") int pagenumber,
+      @RequestParam(defaultValue = "10") int pagesize) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(postService.searchPostsBestRedis(pagenumber, pagesize, keyword));
   }
 
   @PutMapping("/{postId}")

--- a/src/main/java/com/sparta/oceanbackend/common/exception/ExceptionType.java
+++ b/src/main/java/com/sparta/oceanbackend/common/exception/ExceptionType.java
@@ -20,7 +20,8 @@ public enum ExceptionType {
     USER_NOT_FOUND("C004", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     IN_VALID_REQUEST("C005","잘못된 요청 값", HttpStatus.BAD_REQUEST),
     NON_EXISTENT_POST("P001", "존재하지 않는 게시물입니다.", HttpStatus.BAD_REQUEST),
-    NOT_WRITER_POST("P002","본인이 작성한 게시글이 아닙니다.", HttpStatus.BAD_REQUEST);
+    NOT_WRITER_POST("P002","본인이 작성한 게시글이 아닙니다.", HttpStatus.BAD_REQUEST),
+    NOT_ACTION_ALL_ALLOWED_BEST_POST("P003","본인이 작성한 게시글이 아닙니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/sparta/oceanbackend/config/CacheConfig.java
+++ b/src/main/java/com/sparta/oceanbackend/config/CacheConfig.java
@@ -14,7 +14,7 @@ public class CacheConfig {
     @Bean
     // TTL 사용을 위한 외부 캐시 라이브러리 사용 'Caffeine'
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("searchPostsCache");
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("searchPostsCache","searchPostsBestCache");
         cacheManager.setCaffeine(
                 Caffeine.newBuilder()
                         // 캐시 TTL 설정

--- a/src/main/java/com/sparta/oceanbackend/domain/post/entity/Post.java
+++ b/src/main/java/com/sparta/oceanbackend/domain/post/entity/Post.java
@@ -2,6 +2,8 @@ package com.sparta.oceanbackend.domain.post.entity;
 
 import com.sparta.oceanbackend.api.enums.Categorys;
 import com.sparta.oceanbackend.common.entity.Timestamped;
+import com.sparta.oceanbackend.common.exception.ExceptionType;
+import com.sparta.oceanbackend.common.exception.ResponseException;
 import com.sparta.oceanbackend.domain.comment.entity.Comment;
 import com.sparta.oceanbackend.domain.user.entity.User;
 import jakarta.persistence.CascadeType;
@@ -71,5 +73,11 @@ public class Post extends Timestamped {
 
   public void updateCount() {
     this.count = this.count + 1;
+  }
+
+  public void validateActionAllowedForBestPost(){
+    if(this.category==Categorys.BEST_FORUM){
+      throw new ResponseException(ExceptionType.NOT_ACTION_ALL_ALLOWED_BEST_POST);
+    }
   }
 }

--- a/src/main/java/com/sparta/oceanbackend/domain/post/repository/PostQueryDslRepository.java
+++ b/src/main/java/com/sparta/oceanbackend/domain/post/repository/PostQueryDslRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface PostQueryDslRepository {
     Page<PostReadResponse> findByKeyword(String keyword, Pageable pageable);
+    Page<PostReadResponse> findByKeywordInBest(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/sparta/oceanbackend/domain/post/repository/PostQueryDslRepositoryImpl.java
+++ b/src/main/java/com/sparta/oceanbackend/domain/post/repository/PostQueryDslRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.oceanbackend.api.enums.Categorys;
 import com.sparta.oceanbackend.api.post.dto.response.PostReadResponse;
 import com.sparta.oceanbackend.common.CustomPageImpl;
 import com.sparta.oceanbackend.domain.comment.entity.QComment;
@@ -43,6 +44,36 @@ public class PostQueryDslRepositoryImpl implements PostQueryDslRepository {
             .leftJoin(post.user, user)
             .leftJoin(post.comments, comment)
             .where(hasTitle(keyword).or(hasContent(keyword)).or(hasAuthor(keyword)))
+            .groupBy(post.id)
+            .orderBy(post.updatedAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetchResults();
+    List<PostReadResponse> content = results.getResults();
+    long total = results.getTotal();
+    return new CustomPageImpl<>(content, pageable.getPageNumber(), pageable.getPageSize(), total);
+  }
+
+  @Override
+  public Page<PostReadResponse> findByKeywordInBest(String keyword, Pageable pageable) {
+
+    QueryResults<PostReadResponse> results =
+        queryFactory
+            .select(
+                Projections.fields(
+                    PostReadResponse.class,
+                    post.id,
+                    post.title,
+                    user.name.as("name"),
+                    comment.count().as("commentList"),
+                    post.updatedAt))
+            .from(post)
+            .leftJoin(post.user, user)
+            .leftJoin(post.comments, comment)
+            .where(
+                post.category
+                    .eq(Categorys.BEST_FORUM)
+                    .and(hasTitle(keyword).or(hasContent(keyword)).or(hasAuthor(keyword))))
             .groupBy(post.id)
             .orderBy(post.updatedAt.desc())
             .offset(pageable.getOffset())


### PR DESCRIPTION
- 제목 : [#48]feat : 인기게시글 조회 v1,2,3 기능 추가, fix : 유저 인기게시글 생성,수정,삭제 기능 차단
## 🔘Part

- 인기 게시글 조회기능

  <br/>

## 🔎 작업 내용

- 인기게시글에 대한 캐시 논-캐시 기능 API 추가
- 유저가 인기게시글에 대한 직접 작업 차단

  <br/>

## 🔧 앞으로의 과제

- 인기게시글 생성 로직 추가
- Redis 를 이용한 조회수로직 추가