### PR TITLE
[#56]refactor : 게시글 조회수 카운팅 로직변경

### DIFF
--- a/src/main/java/com/sparta/oceanbackend/api/post/scheduler/BestPostScheduler.java
+++ b/src/main/java/com/sparta/oceanbackend/api/post/scheduler/BestPostScheduler.java
@@ -13,9 +13,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class BestPostScheduler {
 
@@ -25,7 +25,10 @@ public class BestPostScheduler {
   private final RedisTemplate<String, Object> redisTemplate;
 
   @Transactional
+  // 테스트 용
   @Scheduled(fixedDelay = 30000, zone = "Asia/Seoul")
+  // 00:30
+  @Scheduled(cron = "0 30 0 * * ?", zone = "Asia/Seoul")
   public void updateBestPosts() {
     // 페이지 처리된 인기 게시글 조회
     List<Post> cachedPosts = postRepository.findByBestCountTop10();

--- a/src/main/java/com/sparta/oceanbackend/api/post/scheduler/PostViewScheduler.java
+++ b/src/main/java/com/sparta/oceanbackend/api/post/scheduler/PostViewScheduler.java
@@ -1,0 +1,54 @@
+package com.sparta.oceanbackend.api.post.scheduler;
+
+import java.util.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostViewScheduler {
+  @Qualifier("redisTemplateView")
+  private final RedisTemplate<String, Integer> redisTemplate;
+
+  private final JdbcTemplate jdbcTemplate;
+
+  private static final String REDIS_KEY_PREFIX = "post:view:*";
+
+  // 테스트용
+  @Scheduled(fixedDelay = 30000, zone = "Asia/Seoul")
+  // 매일 00시 동작
+  @Scheduled(cron = "0 0 0 * * ?")
+  public void syncViewCount() {
+    Set<String> keys = redisTemplate.keys(REDIS_KEY_PREFIX);
+    Map<Long, Integer> viewCounts = new HashMap<>();
+    if (keys != null) {
+      for (String key : keys) {
+        Long postId = Long.parseLong(key.substring(REDIS_KEY_PREFIX.length() - 1));
+        Integer count = redisTemplate.opsForValue().get(key);
+
+        if (count != null) {
+          viewCounts.put(postId, count);
+          redisTemplate.delete(key);
+        }
+      }
+    }
+    if (!viewCounts.isEmpty()) {
+      bulkUpdateViewCount(viewCounts);
+    }
+  }
+
+  private void bulkUpdateViewCount(Map<Long, Integer> viewCounts) {
+    jdbcTemplate.batchUpdate(
+        "UPDATE posts SET count = count + ? WHERE id = ?",
+        viewCounts.entrySet(),
+        viewCounts.size(),
+        (ps, entry) -> {
+          ps.setInt(1, entry.getValue());
+          ps.setLong(2, entry.getKey());
+        });
+  }
+}

--- a/src/main/java/com/sparta/oceanbackend/api/post/service/PostService.java
+++ b/src/main/java/com/sparta/oceanbackend/api/post/service/PostService.java
@@ -28,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PostService {
 
+  private final PostViewService postViewService;
   private final PostRepository postRepository;
   private final KeywordRepository keywordRepository;
 
@@ -166,7 +167,8 @@ public class PostService {
         postRepository
             .findByPostId(postId)
             .orElseThrow(() -> new ResponseException(ExceptionType.NON_EXISTENT_POST));
-    post.updateCount();
+    postViewService.incrementViewCount(post.getId());
+    //    post.updateCount();
     return new PostResponse(post);
   }
 }

--- a/src/main/java/com/sparta/oceanbackend/api/post/service/PostViewService.java
+++ b/src/main/java/com/sparta/oceanbackend/api/post/service/PostViewService.java
@@ -1,0 +1,20 @@
+package com.sparta.oceanbackend.api.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostViewService {
+  @Qualifier("redisTemplateView")
+  private final RedisTemplate<String, Integer> redisTemplate;
+
+  private static final String REDIS_KEY_PREFIX = "post:view:";
+
+  public void incrementViewCount(Long postId) {
+    String key = REDIS_KEY_PREFIX + postId;
+    redisTemplate.opsForValue().increment(key);
+  }
+}

--- a/src/main/java/com/sparta/oceanbackend/config/RedisConfig.java
+++ b/src/main/java/com/sparta/oceanbackend/config/RedisConfig.java
@@ -1,10 +1,9 @@
 package com.sparta.oceanbackend.config;
 
-import java.time.Duration;
-
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -16,10 +15,7 @@ import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.serializer.*;
 
 @Configuration
 @EnableCaching
@@ -40,6 +36,7 @@ public class RedisConfig {
     return new LettuceConnectionFactory(host, port);
   }
 
+  // 인기게시글 직렬화/역직렬화 템플릿
   @Bean(name = "redisTemplate1")
   public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
     RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
@@ -128,5 +125,25 @@ public class RedisConfig {
         .withCacheConfiguration("genericCache", genericCacheConfig)
         .withCacheConfiguration("jacksonCache", jacksonCacheConfig)
         .build();
+  }
+
+  @Bean(name = "redisTemplateView")
+  public RedisTemplate<String, Integer> redisTemplateView(
+      RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Integer> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+
+    // Key는 문자열로 저장
+    template.setKeySerializer(new StringRedisSerializer());
+
+    // Value를 Integer로 저장
+    template.setValueSerializer(new GenericToStringSerializer<>(Integer.class));
+
+    // Optional: Hash Key/Value Serializer 설정
+    template.setHashKeySerializer(new StringRedisSerializer());
+    template.setHashValueSerializer(new GenericToStringSerializer<>(Integer.class));
+
+    template.afterPropertiesSet();
+    return template;
   }
 }


### PR DESCRIPTION
- 제목 : [#56]refactor : 게시글 조회수 카운팅 로직변경
## 🔘Part

- 조회수 캐싱기능

  <br/>

## 🔎 작업 내용

- 기존의 RDB 로 카운팅 하는 로직을 Redis 에서 조회수를 모은후 동기화해주는것으로 변경

  <br/>

## 🔧 앞으로의 과제

- Redis 파이프라인기능을통한 네트워크 최적화
- Redis 백업방안 구상
- 조회수 어뷰징 차단기능구현